### PR TITLE
Fixed spelling errors in the Readme.md and Fixed sorting layers

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This sample shows one method of creating very large RPG maps in Defold. The design is based on the following assumptions:
 
 1. The world is presented one screen at a time. This allows the game to naturally contain enemies and NPC characters within the boundaries of a single screen. The level designer has full control over how the world is presented on the player's screen.
-2. The player character should be able to travel arbitrarily far without the game exhibiting floating point precision issues. These typically cause objects to flutter stangely when they move far from orign.
+2. The player character should be able to travel arbitrarily far without the game exhibiting floating point precision issues. These typically cause objects to flutter stangely when they move far from origin.
 3. The player's movement is restricted by obstacles on the map, so the level designer can lead the player between screens using trees, rocks, water and other obstacles.
 4. It should be possible to mix and match tilemaps, sprites and other visual content.
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This sample shows one method of creating very large RPG maps in Defold. The design is based on the following assumptions:
 
 1. The world is presented one screen at a time. This allows the game to naturally contain enemies and NPC characters within the boundaries of a single screen. The level designer has full control over how the world is presented on the player's screen.
-2. The player character should be able to travel arbitrarily far without the game exhibiting floating point precision issues. These typically cause objects to flutter stangely when they move far from origo.
+2. The player character should be able to travel arbitrarily far without the game exhibiting floating point precision issues. These typically cause objects to flutter stangely when they move far from orign.
 3. The player's movement is restricted by obstacles on the map, so the level designer can lead the player between screens using trees, rocks, water and other obstacles.
 4. It should be possible to mix and match tilemaps, sprites and other visual content.
 

--- a/main/hero.go
+++ b/main/hero.go
@@ -65,6 +65,7 @@ embedded_components {
   "linear_damping: 0.0\n"
   "angular_damping: 0.0\n"
   "locked_rotation: false\n"
+  "bullet: false\n"
   ""
   position {
     x: 0.0

--- a/main/map/0-0.tilemap
+++ b/main/map/0-0.tilemap
@@ -1686,7 +1686,7 @@ layers {
 }
 layers {
   id: "level1"
-  z: 0.0
+  z: 1.0
   is_visible: 1
   cell {
     x: 0

--- a/main/map/0-1.tilemap
+++ b/main/map/0-1.tilemap
@@ -1686,7 +1686,7 @@ layers {
 }
 layers {
   id: "level1"
-  z: 0.0
+  z: 1.0
   is_visible: 1
   cell {
     x: 0

--- a/main/map/0-2.tilemap
+++ b/main/map/0-2.tilemap
@@ -1686,7 +1686,7 @@ layers {
 }
 layers {
   id: "layer1"
-  z: 0.0
+  z: 1.0
   is_visible: 1
   cell {
     x: 0

--- a/main/map/1-0.tilemap
+++ b/main/map/1-0.tilemap
@@ -1686,7 +1686,7 @@ layers {
 }
 layers {
   id: "level1"
-  z: 0.0
+  z: 1.0
   is_visible: 1
   cell {
     x: 0

--- a/main/map/1-1.tilemap
+++ b/main/map/1-1.tilemap
@@ -1686,7 +1686,7 @@ layers {
 }
 layers {
   id: "layer"
-  z: 0.0
+  z: 1.0
   is_visible: 1
   cell {
     x: 0

--- a/main/map/1-2.tilemap
+++ b/main/map/1-2.tilemap
@@ -1686,7 +1686,7 @@ layers {
 }
 layers {
   id: "level1"
-  z: 0.0
+  z: 1.0
   is_visible: 1
   cell {
     x: 0

--- a/main/map/2-0.tilemap
+++ b/main/map/2-0.tilemap
@@ -1686,7 +1686,7 @@ layers {
 }
 layers {
   id: "layer1"
-  z: 0.0
+  z: 1.0
   is_visible: 1
   cell {
     x: 1

--- a/main/map/2-1.tilemap
+++ b/main/map/2-1.tilemap
@@ -1686,7 +1686,7 @@ layers {
 }
 layers {
   id: "level1"
-  z: 0.0
+  z: 1.0
   is_visible: 1
   cell {
     x: 0

--- a/main/map/2-2.tilemap
+++ b/main/map/2-2.tilemap
@@ -1686,7 +1686,7 @@ layers {
 }
 layers {
   id: "level1"
-  z: 0.0
+  z: 1.0
   is_visible: 1
   cell {
     x: 0

--- a/main/screens/0-0.collection
+++ b/main/screens/0-0.collection
@@ -51,6 +51,7 @@ embedded_instances {
   "linear_damping: 0.0\\n"
   "angular_damping: 0.0\\n"
   "locked_rotation: false\\n"
+  "bullet: false\\n"
   "\"\n"
   "  position {\n"
   "    x: 0.0\n"

--- a/main/screens/0-1.collection
+++ b/main/screens/0-1.collection
@@ -93,6 +93,7 @@ embedded_instances {
   "linear_damping: 0.0\\n"
   "angular_damping: 0.0\\n"
   "locked_rotation: false\\n"
+  "bullet: false\\n"
   "\"\n"
   "  position {\n"
   "    x: 0.0\n"

--- a/main/screens/0-2.collection
+++ b/main/screens/0-2.collection
@@ -51,6 +51,7 @@ embedded_instances {
   "linear_damping: 0.0\\n"
   "angular_damping: 0.0\\n"
   "locked_rotation: false\\n"
+  "bullet: false\\n"
   "\"\n"
   "  position {\n"
   "    x: 0.0\n"

--- a/main/screens/1-0.collection
+++ b/main/screens/1-0.collection
@@ -51,6 +51,7 @@ embedded_instances {
   "linear_damping: 0.0\\n"
   "angular_damping: 0.0\\n"
   "locked_rotation: false\\n"
+  "bullet: false\\n"
   "\"\n"
   "  position {\n"
   "    x: 0.0\n"

--- a/main/screens/1-1.collection
+++ b/main/screens/1-1.collection
@@ -51,6 +51,7 @@ embedded_instances {
   "linear_damping: 0.0\\n"
   "angular_damping: 0.0\\n"
   "locked_rotation: false\\n"
+  "bullet: false\\n"
   "\"\n"
   "  position {\n"
   "    x: 0.0\n"

--- a/main/screens/1-2.collection
+++ b/main/screens/1-2.collection
@@ -51,6 +51,7 @@ embedded_instances {
   "linear_damping: 0.0\\n"
   "angular_damping: 0.0\\n"
   "locked_rotation: false\\n"
+  "bullet: false\\n"
   "\"\n"
   "  position {\n"
   "    x: 0.0\n"

--- a/main/screens/2-0.collection
+++ b/main/screens/2-0.collection
@@ -51,6 +51,7 @@ embedded_instances {
   "linear_damping: 0.0\\n"
   "angular_damping: 0.0\\n"
   "locked_rotation: false\\n"
+  "bullet: false\\n"
   "\"\n"
   "  position {\n"
   "    x: 0.0\n"

--- a/main/screens/2-1.collection
+++ b/main/screens/2-1.collection
@@ -51,6 +51,7 @@ embedded_instances {
   "linear_damping: 0.0\\n"
   "angular_damping: 0.0\\n"
   "locked_rotation: false\\n"
+  "bullet: false\\n"
   "\"\n"
   "  position {\n"
   "    x: 0.0\n"

--- a/main/screens/2-2.collection
+++ b/main/screens/2-2.collection
@@ -51,6 +51,7 @@ embedded_instances {
   "linear_damping: 0.0\\n"
   "angular_damping: 0.0\\n"
   "locked_rotation: false\\n"
+  "bullet: false\\n"
   "\"\n"
   "  position {\n"
   "    x: 0.0\n"


### PR DESCRIPTION
Hello :) /

This is my first commit to a Defold foundation project!


I fixed a spelling error in the readme.md where "Origo should be Origin." and I also fixed sorting issues for detail objects in the editor. Before detail objects were not showing up in the editor due to both the grass layer and layer1 being on the same sorting layer. I have tested this and have ensured that collisions are working and it looks proper in both play mode and in the editor.

I am looking forward to working with defold in the future. 

- Ben